### PR TITLE
Simple Windows support

### DIFF
--- a/src/LocalInstaller.php
+++ b/src/LocalInstaller.php
@@ -80,6 +80,15 @@ class LocalInstaller implements InstallerInterface {
 	 * @throws \Exception When symlink fails
 	 */
 	private function symlink($originDir, $targetDir) {
+		// Windows logic
+		if (defined('PHP_WINDOWS_VERSION_MAJOR')) {			
+			exec('mklink /J ' . escapeshellarg($targetDir) . ' ' . escapeshellarg($originDir), $output, $resultCode);
+			
+			if ($resultCode === 0) {
+				return;
+			}
+		}
+		
 		@mkdir(dirname($targetDir), 0777, true);
 
 		$ok = false;


### PR DESCRIPTION
By default symlink() on Windows tries to do a hardlink which requires administrator access.

`mklink /J` creates a junction, which should work fine in most cases.
