### PR TITLE
Restore php 5.3 compatibility

### DIFF
--- a/src/ComposerLocaldevPlugin.php
+++ b/src/ComposerLocaldevPlugin.php
@@ -76,7 +76,7 @@ class ComposerLocaldevPlugin implements PluginInterface {
 	}
 	
 	private function getLinks($packages, $rootName) {
-		$requires = [];
+		$requires = array();
 		foreach ($packages as $name) {
 			$package = $this->repo->findPackage($name, 'dev-live');
 			if ($package !== null) {

--- a/src/LocalInstaller.php
+++ b/src/LocalInstaller.php
@@ -87,7 +87,7 @@ class LocalInstaller implements InstallerInterface {
 	private function symlink($originDir, $targetDir) {
 		// Windows logic
 		if (defined('PHP_WINDOWS_VERSION_MAJOR')) {
-			$output = [];
+			$output = array();
 			$return = 0;
 			exec('mklink /J ' . escapeshellarg($targetDir) . ' ' . escapeshellarg($originDir), $output, $return);
 			


### PR DESCRIPTION
Had a minor snafu when trying to install with this with dinosaur php 5.3...   composer.json states compatibility with php >= 5.3, but just there's a handful of php 5.4-style arrays used in the codebase that conflict with that.  Changing the arrays resolved the issue and made the plugin work successfully for me on 5.3.